### PR TITLE
call printdiags when using --config flag

### DIFF
--- a/cmd/cli/command/access/ensure.go
+++ b/cmd/cli/command/access/ensure.go
@@ -100,9 +100,13 @@ var ensureCommand = cli.Command{
 
 		res, err := client.BatchEnsure(ctx, connect.NewRequest(&req))
 		if err != nil {
+
 			si.Stop()
 			return err
 		}
+
+		//prints response diag messages
+		printdiags.Print(res.Msg.Diagnostics, nil)
 
 		si.Stop()
 


### PR DESCRIPTION
Diag messages were not being printing when the --confirm flag was passed.
PR fixes that functionality so that it works the same as with dry run