### PR TITLE
Josh/cf 2756 add cf manage deployment logs watchget command

### DIFF
--- a/.changeset/rare-ways-exercise.md
+++ b/.changeset/rare-ways-exercise.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": minor
+---
+
+Add the manage > deployment > logs get/watch sub commands. Assists in filtering and tailing logs for a Common Fate deployment.

--- a/cmd/cli/command/manage/deployment/deployment.go
+++ b/cmd/cli/command/manage/deployment/deployment.go
@@ -1,0 +1,15 @@
+package deployment
+
+import (
+	"github.com/common-fate/cli/cmd/cli/command/manage/deployment/logs"
+	"github.com/urfave/cli/v2"
+)
+
+var Command = cli.Command{
+	Name:    "deployment",
+	Aliases: []string{"dep"},
+	Usage:   "Manage your Common Fate Deployment",
+	Subcommands: []*cli.Command{
+		&logs.Command,
+	},
+}

--- a/cmd/cli/command/manage/deployment/logs/get.go
+++ b/cmd/cli/command/manage/deployment/logs/get.go
@@ -1,0 +1,127 @@
+package logs
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/TylerBrock/saw/blade"
+	sawconfig "github.com/TylerBrock/saw/config"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/common-fate/clio"
+	"github.com/urfave/cli/v2"
+)
+
+var getCommand = cli.Command{
+	Name: "get",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{Name: "service", Aliases: []string{"s"}, Usage: "The service to watch logs for. Services: " + strings.Join(ServiceNames, ", "), Required: false},
+		&cli.StringFlag{Name: "start", Usage: "Start time", Value: "-5m", Required: false},
+		&cli.StringFlag{Name: "end", Usage: "End time", Value: "now", Required: false},
+		&cli.StringFlag{Name: "filter", Usage: "Filter logs using a keyword, see the AWS documentation for details and syntax https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html"},
+	},
+	Description: "Get logs from CloudWatch",
+	Action: func(c *cli.Context) error {
+		services := c.StringSlice("service")
+		err := validateServices(services)
+		if err != nil {
+			return err
+		}
+
+		ctx := c.Context
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		wg := sync.WaitGroup{}
+		start := c.String("start")
+		end := c.String("end")
+		if len(services) == 0 {
+			services = ServiceNames
+		}
+		for _, service := range services {
+
+			wg.Add(1)
+			go func(lg, s, start, end string) {
+				clio.Info("Starting to get logs for %s, log group id: %s", s, lg)
+				hasLogs := false
+				cwClient := cloudwatchlogs.NewFromConfig(cfg)
+
+				// Because the saw library emits its own errors and os.exits.
+				// We first check whether logs exist for the log group.
+				// if they dont, emit a warning rather than terminating the command
+				o, _ := cwClient.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+					LogGroupNamePrefix: &lg,
+				})
+				if o != nil && len(o.LogGroups) == 1 {
+					lo, err := cwClient.DescribeLogStreams(ctx, &cloudwatchlogs.DescribeLogStreamsInput{
+						LogGroupName: o.LogGroups[0].LogGroupName,
+						Limit:        aws.Int32(1),
+					})
+					_ = err
+					if lo != nil && len(lo.LogStreams) != 0 {
+						hasLogs = true
+					}
+				}
+				if hasLogs {
+					getEvents(GetEventsOpts{Group: lg, Start: start, End: end}, cfg.Region, c.String("filter"))
+				} else {
+					clio.Warnf("No logs found for %s, the service may not have run yet. Log group id: %s", s, lg)
+				}
+
+				wg.Done()
+			}(fmt.Sprintf("%s-%s-%s", c.String("namespace"), c.String("stage"), service), service, start, end)
+		}
+		wg.Wait()
+
+		return nil
+	},
+}
+
+func validateServices(services []string) error {
+	for _, s := range services {
+		if !slices.Contains(ServiceNames, s) {
+			return fmt.Errorf("invalid service: %s options are: %s", s, strings.Join(ServiceNames, ", "))
+		}
+	}
+	return nil
+}
+func getCFNOutput(key string, outputs []types.Output) (string, error) {
+	for _, o := range outputs {
+		if o.OutputKey != nil && *o.OutputKey == key {
+			return *o.OutputValue, nil
+		}
+	}
+	return "", fmt.Errorf("could not find %s output", key)
+}
+
+type GetEventsOpts struct {
+	Group string
+	Start string
+	End   string
+}
+
+func getEvents(opts GetEventsOpts, region string, filter string) {
+	sawcfg := sawconfig.Configuration{
+		Group:  opts.Group,
+		Start:  opts.Start,
+		End:    opts.End,
+		Filter: filter,
+	}
+
+	outputcfg := sawconfig.OutputConfiguration{
+		Pretty: true,
+	}
+
+	b := blade.NewBlade(&sawcfg, &sawconfig.AWSConfiguration{Region: region}, &outputcfg)
+	// The blade package will OS.Exit if the loggroup is not found
+	// logroup will not be found possible if no logs have been created yet for the lambda
+	// resulting in
+	// Error ResourceNotFoundException: The specified log group does not exist.
+	b.GetEvents()
+}

--- a/cmd/cli/command/manage/deployment/logs/logs.go
+++ b/cmd/cli/command/manage/deployment/logs/logs.go
@@ -1,0 +1,25 @@
+package logs
+
+import "github.com/urfave/cli/v2"
+
+var Command = cli.Command{
+	Name:        "logs",
+	Description: "View recent application logs from Cloudwatch or stream them in real time",
+	Usage:       "View recent application logs from Cloudwatch or stream them in real time",
+	Action:      cli.ShowSubcommandHelp,
+	Subcommands: []*cli.Command{&getCommand, &watchCommand},
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "namespace", Value: "common-fate", Usage: "Your Common Fate infrastructure deployment namespace"},
+		&cli.StringFlag{Name: "stage", Value: "prod", Usage: "Your Common Fate infrastructure deployment stage"},
+	},
+}
+
+// the services names are defined here for this CLI command, and may be different in other usages
+var ServiceNames = []string{
+	"access-handler",
+	"authz",
+	"control-plane",
+	"otel-collector",
+	"provisioner",
+	"web",
+}

--- a/cmd/cli/command/manage/deployment/logs/watch.go
+++ b/cmd/cli/command/manage/deployment/logs/watch.go
@@ -1,0 +1,68 @@
+package logs
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/TylerBrock/saw/blade"
+	sawconfig "github.com/TylerBrock/saw/config"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/common-fate/clio"
+	"github.com/urfave/cli/v2"
+)
+
+var watchCommand = cli.Command{
+	Name: "watch",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{Name: "service", Aliases: []string{"s"}, Usage: "The service to watch logs for. Services: " + strings.Join(ServiceNames, ", "), Required: false},
+		&cli.StringFlag{Name: "filter", Usage: "Filter logs using a keyword, see the AWS documentation for details and syntax https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html"},
+	},
+	Description: "Stream logs from CloudWatch",
+	Action: func(c *cli.Context) error {
+		services := c.StringSlice("service")
+		err := validateServices(services)
+		if err != nil {
+			return err
+		}
+		ctx := c.Context
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		wg := sync.WaitGroup{}
+		// if no services supplied, watch all
+		if len(services) == 0 {
+			services = ServiceNames
+		}
+		for _, service := range services {
+
+			wg.Add(1)
+			go func(lg, s string) {
+				clio.Infof("Starting to watch logs for %s, log group id: %s", s, lg)
+				watchEvents(lg, cfg.Region, c.String("filter"))
+				wg.Done()
+			}(fmt.Sprintf("%s-%s-%s", c.String("namespace"), c.String("stage"), service), service)
+		}
+
+		wg.Wait()
+
+		return nil
+	},
+}
+
+func watchEvents(group string, region string, filter string) {
+	sawcfg := sawconfig.Configuration{
+		Group:  group,
+		Filter: filter,
+	}
+
+	outputcfg := sawconfig.OutputConfiguration{
+		Pretty: true,
+	}
+	// The Blade api from saw is not very configurable
+	// The most we can do is pass in a Region
+	b := blade.NewBlade(&sawcfg, &sawconfig.AWSConfiguration{Region: region}, &outputcfg)
+	b.StreamEvents()
+}

--- a/cmd/cli/command/manage/manage.go
+++ b/cmd/cli/command/manage/manage.go
@@ -1,0 +1,15 @@
+package manage
+
+import (
+	"github.com/common-fate/cli/cmd/cli/command/manage/deployment"
+	"github.com/urfave/cli/v2"
+)
+
+var Command = cli.Command{
+	Name:    "manage",
+	Aliases: []string{"mng"},
+	Usage:   "Manage Common Fate",
+	Subcommands: []*cli.Command{
+		&deployment.Command,
+	},
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/common-fate/cli/cmd/cli/command/aws"
 	"github.com/common-fate/cli/cmd/cli/command/entity"
 	"github.com/common-fate/cli/cmd/cli/command/identity"
+	"github.com/common-fate/cli/cmd/cli/command/manage"
 	"github.com/common-fate/cli/cmd/cli/command/policyset"
 	"github.com/common-fate/cli/internal/build"
 	glidecli "github.com/common-fate/glide-cli"
@@ -116,6 +117,7 @@ func main() {
 			&command.Configure,
 			&command.Context,
 			&aws.Command,
+			&manage.Command,
 		},
 	}
 	clio.SetLevelFromEnv("CF_LOG")


### PR DESCRIPTION
Add management command with aliases, allowing get and watch with filtering and window flags

`cf manage deployment logs watch`
`cf manage deployment logs get`
`cf mng dep logs watch`
`cf mng dep logs get`

`cf mng dep logs get --s control-plane`
`cf mng dep logs get --s control-plane --filter error`