### PR TITLE
update sdk version with accessrequest returned in the message

### DIFF
--- a/cmd/cli/command/access/dry_run.go
+++ b/cmd/cli/command/access/dry_run.go
@@ -53,7 +53,7 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 
 	var hasChanges bool
 
-	for _, g := range res.Msg.Grants {
+	for _, g := range res.Msg.Changes {
 		names[eid.New("Access::Grant", g.Grant.Id)] = g.Grant.Name
 
 		exp := "<invalid expiry>"

--- a/cmd/cli/command/access/ensure.go
+++ b/cmd/cli/command/access/ensure.go
@@ -124,7 +124,7 @@ var ensureCommand = cli.Command{
 
 			names := map[eid.EID]string{}
 
-			for _, g := range res.Msg.Grants {
+			for _, g := range res.Msg.Changes {
 				names[eid.New("Access::Grant", g.Grant.Id)] = g.Grant.Name
 
 				exp := "<invalid expiry>"

--- a/cmd/cli/command/aws/rds/rds.go
+++ b/cmd/cli/command/aws/rds/rds.go
@@ -112,7 +112,7 @@ var proxyCommand = cli.Command{
 			clio.Debugw("BatchEnsure response", "response", res)
 
 			names := map[eid.EID]string{}
-			for _, g := range res.Msg.Grants {
+			for _, g := range res.Msg.Changes {
 				names[eid.New("Access::Grant", g.Grant.Id)] = g.Grant.Name
 
 				exp := "<invalid expiry>"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/common-fate/glide-cli v0.6.0
 	github.com/common-fate/grab v1.2.0
 	github.com/common-fate/granted v0.20.6
-	github.com/common-fate/sdk v1.5.0
+	github.com/common-fate/sdk v1.5.1-0.20240222012459-97130a0b168b
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,10 @@ github.com/common-fate/sdk v1.4.2-0.20240219025136-73f7c6892e58 h1:pUm9cYLeUNvmL
 github.com/common-fate/sdk v1.4.2-0.20240219025136-73f7c6892e58/go.mod h1:WJfjdFPhVEcLxo5keKrm3zsXz+eZnxoQ/kh8Ef4EAmc=
 github.com/common-fate/sdk v1.5.0 h1:eS99ptO0RLJ5MWCuuuHeo4F2Mx16e56CZwEBoT3lwIE=
 github.com/common-fate/sdk v1.5.0/go.mod h1:WJfjdFPhVEcLxo5keKrm3zsXz+eZnxoQ/kh8Ef4EAmc=
+github.com/common-fate/sdk v1.5.1-0.20240222000336-6eb68bdb4c26 h1:6BfLChUOxxu0PJVPbbFFXZ9uE4umJsVQMxSsLhoFyP8=
+github.com/common-fate/sdk v1.5.1-0.20240222000336-6eb68bdb4c26/go.mod h1:WJfjdFPhVEcLxo5keKrm3zsXz+eZnxoQ/kh8Ef4EAmc=
+github.com/common-fate/sdk v1.5.1-0.20240222012459-97130a0b168b h1:1rzbQnL+8kwBhbmEMvTyeO7ku3RGVsTl2vXZ+25m/HE=
+github.com/common-fate/sdk v1.5.1-0.20240222012459-97130a0b168b/go.mod h1:WJfjdFPhVEcLxo5keKrm3zsXz+eZnxoQ/kh8Ef4EAmc=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=
 github.com/common-fate/useragent v0.1.0/go.mod h1:GjXGR6cDiMboDP04qlfDfA5HTbeoRSoNgQWDAyOdW9o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=


### PR DESCRIPTION
Bumps sdk version to include access request in batch ensure requests

Decided to keep the grant changes on the response as this makes it a non breaking change to the api 
And also it was the cleanest way to keep the grant changes functionality.

The integration tests have been updated to check the grant changes.