### PR TITLE
Background job cli command improvements

### DIFF
--- a/.changeset/mighty-adults-shave.md
+++ b/.changeset/mighty-adults-shave.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": patch
+---
+
+Adds cli command for retrying background jobs if they are retryable. Also adds timestamp to background job list command

--- a/cmd/cli/command/deployment/backgroundjobs.go
+++ b/cmd/cli/command/deployment/backgroundjobs.go
@@ -20,7 +20,7 @@ import (
 var backgroundJobsCommand = cli.Command{
 	Name:        "background-jobs",
 	Usage:       "Manage background jobs",
-	Subcommands: []*cli.Command{&cancelJobCommand, &batchCancelJobCommand},
+	Subcommands: []*cli.Command{&cancelJobCommand, &batchCancelJobCommand, &retryJobCommand, &batchRetryJobCommand},
 }
 
 var cancelJobCommand = cli.Command{
@@ -47,6 +47,35 @@ var cancelJobCommand = cli.Command{
 		}
 
 		clio.Success("cancelled job successfully")
+
+		return nil
+	},
+}
+
+var retryJobCommand = cli.Command{
+	Name:  "retry",
+	Usage: "Retry a background job",
+	Flags: []cli.Flag{
+		&cli.Int64Flag{Name: "id", Required: true},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+
+		cfg, err := config.LoadDefault(ctx)
+		if err != nil {
+			return err
+		}
+
+		client := reset.NewFromConfig(cfg)
+
+		_, err = client.RetryBackgroundJob(ctx, connect.NewRequest(&resetv1alpha1.RetryBackgroundJobRequest{
+			Id: c.Int64("id"),
+		}))
+		if err != nil {
+			return err
+		}
+
+		clio.Success("retried job successfully")
 
 		return nil
 	},
@@ -108,6 +137,68 @@ var batchCancelJobCommand = cli.Command{
 				continue
 			}
 			clio.Successf("cancelled job: %v successfully", id)
+		}
+
+		return nil
+	},
+}
+
+var batchRetryJobCommand = cli.Command{
+	Name:  "retry-batch",
+	Usage: "Retry background jobs",
+	Flags: []cli.Flag{
+		&cli.Int64SliceFlag{Name: "ids"},
+		&cli.StringSliceFlag{Name: "kinds"},
+		&cli.StringFlag{Name: "state", Usage: "valid states are ['available','retryable','running','scheduled']"},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+
+		cfg, err := config.LoadDefault(ctx)
+		if err != nil {
+			return err
+		}
+
+		client := reset.NewFromConfig(cfg)
+
+		ids := c.Int64Slice("ids")
+		kinds := c.StringSlice("kinds")
+		if len(kinds) > 0 && c.String("state") == "" {
+			return errors.New("--state is required when specifiying kinds")
+		}
+		if c.String("state") != "" {
+			state, err := JobStateFromString(c.String("state"))
+			if err != nil {
+				return err
+			}
+			diagClient := diagnostic.NewFromConfig(cfg)
+			backgroundJobs, err := diagClient.ListBackgroundJobs(ctx, connect.NewRequest(&diagnosticv1alpha1.ListBackgroundJobsRequest{
+				Kinds: kinds,
+				Count: grab.Ptr(int64(10000)),
+				State: state,
+			}))
+			if err != nil {
+				return err
+			}
+			for _, job := range backgroundJobs.Msg.Jobs {
+				ids = append(ids, job.Id)
+			}
+		}
+
+		slices.Sort(ids)
+		ids = slices.Compact(ids)
+
+		clio.Infow("Retrying jobs", "count", len(ids), "job_ids", ids)
+		for _, id := range ids {
+			clio.Successf("Retrying job: %v", id)
+			_, err = client.RetryBackgroundJob(ctx, connect.NewRequest(&resetv1alpha1.RetryBackgroundJobRequest{
+				Id: id,
+			}))
+			if err != nil {
+				clio.Errorw(fmt.Sprintf("failed to retry job: %v", id), zap.Error(err))
+				continue
+			}
+			clio.Successf("retried job: %v successfully", id)
 		}
 
 		return nil

--- a/cmd/cli/command/deployment/diagnostics.go
+++ b/cmd/cli/command/deployment/diagnostics.go
@@ -151,10 +151,10 @@ var backgroundTasksCommand = cli.Command{
 		case "text":
 			fmt.Println("Background Jobs")
 			tbl := table.New(os.Stdout)
-			tbl.Columns("ID", "KIND", "STATE")
+			tbl.Columns("ID", "KIND", "STATE", "OCCURED_AT")
 
 			for _, job := range backgroundJobs.Msg.Jobs {
-				tbl.Row(strconv.Itoa(int(job.Id)), job.Kind, job.State)
+				tbl.Row(strconv.Itoa(int(job.Id)), job.Kind, job.State, job.CreatedAt.AsTime().String())
 			}
 
 			err = tbl.Flush()

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/common-fate/glide-cli v0.6.0
 	github.com/common-fate/grab v1.3.0
 	github.com/common-fate/granted v0.20.6
-	github.com/common-fate/sdk v1.12.4-0.20240321002947-cd6d197b47da
+	github.com/common-fate/sdk v1.14.0
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/common-fate/glide-cli v0.6.0
 	github.com/common-fate/grab v1.3.0
 	github.com/common-fate/granted v0.20.6
-	github.com/common-fate/sdk v1.11.0
+	github.com/common-fate/sdk v1.12.4-0.20240321002947-cd6d197b47da
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/common-fate/provider-registry-sdk-go v0.19.0 h1:V5ZUP5jvNFM0FVXH8akXL
 github.com/common-fate/provider-registry-sdk-go v0.19.0/go.mod h1:nD5qKGinFLxxhISpWHYCv5v7bQhB1wKap4jA8bmztOw=
 github.com/common-fate/sdk v1.11.0 h1:nGPQ52wzZef6j8bJHIiLlHtd1cFmtVKXmirFn1HWHp4=
 github.com/common-fate/sdk v1.11.0/go.mod h1:WJfjdFPhVEcLxo5keKrm3zsXz+eZnxoQ/kh8Ef4EAmc=
+github.com/common-fate/sdk v1.12.4-0.20240321002947-cd6d197b47da h1:fGLz6mwgkUPjLf+IpjdLYJgp/olNMMdmIC3OdZnso6Q=
+github.com/common-fate/sdk v1.12.4-0.20240321002947-cd6d197b47da/go.mod h1:5CJxmDmjk7hRPbvEQcoH6qiOrAFIgLsqAdokOZZ4mKw=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=
 github.com/common-fate/useragent v0.1.0/go.mod h1:GjXGR6cDiMboDP04qlfDfA5HTbeoRSoNgQWDAyOdW9o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/common-fate/sdk v1.11.0 h1:nGPQ52wzZef6j8bJHIiLlHtd1cFmtVKXmirFn1HWHp
 github.com/common-fate/sdk v1.11.0/go.mod h1:WJfjdFPhVEcLxo5keKrm3zsXz+eZnxoQ/kh8Ef4EAmc=
 github.com/common-fate/sdk v1.12.4-0.20240321002947-cd6d197b47da h1:fGLz6mwgkUPjLf+IpjdLYJgp/olNMMdmIC3OdZnso6Q=
 github.com/common-fate/sdk v1.12.4-0.20240321002947-cd6d197b47da/go.mod h1:5CJxmDmjk7hRPbvEQcoH6qiOrAFIgLsqAdokOZZ4mKw=
+github.com/common-fate/sdk v1.14.0 h1:gHF2dBAtflzno9gJ8pzhyd2l1XcKfjilXiOBt+KsPdM=
+github.com/common-fate/sdk v1.14.0/go.mod h1:5CJxmDmjk7hRPbvEQcoH6qiOrAFIgLsqAdokOZZ4mKw=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=
 github.com/common-fate/useragent v0.1.0/go.mod h1:GjXGR6cDiMboDP04qlfDfA5HTbeoRSoNgQWDAyOdW9o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=


### PR DESCRIPTION
Adds timestamp when listing any background tasks
![Screenshot 2024-03-21 at 11 41 02 AM](https://github.com/common-fate/cli/assets/33018450/d907eaad-3046-4e2b-9943-f994028ccf1b)

Adds new command `retry` and `retry-batch` to allow retrying of background jobs