### PR TITLE
Adds support for specifying config sources via the CF_CONFIG_SOURCES environment variable

### DIFF
--- a/.changeset/heavy-houses-wait.md
+++ b/.changeset/heavy-houses-wait.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": minor
+---
+
+Adds support for specifying config sources via the CF_CONFIG_SOURCES environment variable. You can now use `CF_CONFIG_SOURCES=env` in CI environments to configure the CLI entirely via environment variables.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/common-fate/glide-cli v0.6.0
 	github.com/common-fate/grab v1.3.0
 	github.com/common-fate/granted v0.20.6
-	github.com/common-fate/sdk v1.18.0
+	github.com/common-fate/sdk v1.19.0
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/common-fate/sdk v1.17.1-0.20240403163546-0d2578953108 h1:qcZBaCq8Z4lU
 github.com/common-fate/sdk v1.17.1-0.20240403163546-0d2578953108/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/sdk v1.18.0 h1:CfkRa8Yq4NI6z3EqrjMT3mPNOk2ZDVnLfeNPrqxn4jc=
 github.com/common-fate/sdk v1.18.0/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
+github.com/common-fate/sdk v1.19.0 h1:wyURG5LQ32zqyDG87iEzWH0YDiJDRzcQVbxmhMTmKnw=
+github.com/common-fate/sdk v1.19.0/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=
 github.com/common-fate/useragent v0.1.0/go.mod h1:GjXGR6cDiMboDP04qlfDfA5HTbeoRSoNgQWDAyOdW9o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=


### PR DESCRIPTION
Adds support for specifying config sources via the CF_CONFIG_SOURCES environment variable. You can now use `CF_CONFIG_SOURCES=env` in CI environments to configure the CLI entirely via environment variables.