### PR TITLE
don't require the --duration flag to be specified for each requested entitlement

### DIFF
--- a/.changeset/famous-experts-joke.md
+++ b/.changeset/famous-experts-joke.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": patch
+---
+
+Fixes an issue where the --duration flag was required for each entitlement being requested


### PR DESCRIPTION
specifying separate durations in the same request isn't a use case we've seen, and requiring --duration multiple times hurts our UX.