### PR TITLE
Batch ensure to create aws profile in ~/.aws/config if it doesn't exist

### DIFF
--- a/.changeset/sour-wasps-camp.md
+++ b/.changeset/sour-wasps-camp.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": minor
+---
+
+batch ensure will attempt to add a profile to ~/.aws/config for the requested target and role

--- a/awsconfig/config.go
+++ b/awsconfig/config.go
@@ -41,7 +41,7 @@ func GetAWSConfigPath() string {
 }
 
 // loadAWSConfigFile loads the `~/.aws/config` file, and creates it if it doesn't exist.
-func LoadAWSConfigFile() (*ini.File, string, error) {
+func Load() (*ini.File, string, error) {
 	filepath := GetAWSConfigPath()
 
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {

--- a/awsconfig/config.go
+++ b/awsconfig/config.go
@@ -1,0 +1,69 @@
+package awsconfig
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/common-fate/clio"
+	"gopkg.in/ini.v1"
+)
+
+const (
+	// permission for user to read/write/execute.
+	USER_READ_WRITE_PERM = 0700
+)
+
+func loadAWSConfigFileFromPath(filepath string) (*ini.File, error) {
+	awsConfig, err := ini.LoadSources(ini.LoadOptions{
+		SkipUnrecognizableLines: true,
+		AllowNonUniqueSections:  true,
+		AllowNestedValues:       true,
+	}, filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	return awsConfig, nil
+}
+
+// Find the ~/.aws/config absolute path based on OS.
+func getDefaultAWSConfigLocation() (string, error) {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	configPath := filepath.Join(h, ".aws", "config")
+	return configPath, nil
+}
+
+// loadAWSConfigFile loads the `~/.aws/config` file, and creates it if it doesn't exist.
+func LoadAWSConfigFile() (*ini.File, string, error) {
+	filepath, err := getDefaultAWSConfigLocation()
+	if err != nil {
+		return nil, "", err
+	}
+
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		clio.Infof("created AWS config file: %s", filepath)
+
+		// create all parent directory if necessary.
+		err := os.MkdirAll(path.Dir(filepath), USER_READ_WRITE_PERM)
+		if err != nil {
+			return nil, "", err
+		}
+
+		_, err = os.Create(filepath)
+		if err != nil {
+			return nil, "", fmt.Errorf("unable to create AWS config file: %w", err)
+		}
+	}
+
+	awsConfig, err := loadAWSConfigFileFromPath(filepath)
+	if err != nil {
+		return nil, "", err
+	}
+	return awsConfig, filepath, nil
+}

--- a/awsconfig/config.go
+++ b/awsconfig/config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/common-fate/clio"
 	"gopkg.in/ini.v1"
 )
@@ -28,23 +28,21 @@ func loadAWSConfigFileFromPath(filepath string) (*ini.File, error) {
 	return awsConfig, nil
 }
 
-// Find the ~/.aws/config absolute path based on OS.
-func getDefaultAWSConfigLocation() (string, error) {
-	h, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
+// GetAWSConfigPath will return default AWS config file path unless $AWS_CONFIG_FILE
+// environment variable is set
+func GetAWSConfigPath() string {
+	file := os.Getenv("AWS_CONFIG_FILE")
+	if file != "" {
+		clio.Debugf("using aws config filepath: %s", file)
+		return file
 	}
 
-	configPath := filepath.Join(h, ".aws", "config")
-	return configPath, nil
+	return config.DefaultSharedConfigFilename()
 }
 
 // loadAWSConfigFile loads the `~/.aws/config` file, and creates it if it doesn't exist.
 func LoadAWSConfigFile() (*ini.File, string, error) {
-	filepath, err := getDefaultAWSConfigLocation()
-	if err != nil {
-		return nil, "", err
-	}
+	filepath := GetAWSConfigPath()
 
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
 		clio.Infof("created AWS config file: %s", filepath)

--- a/awsconfig/merge.go
+++ b/awsconfig/merge.go
@@ -1,4 +1,4 @@
-package access
+package awsconfig
 
 import (
 	"strings"
@@ -9,19 +9,12 @@ import (
 )
 
 type MergeOpts struct {
-	Config              *ini.File
-	Prefix              string
-	ProfileName         string
-	ProfileAttributes   []*awsv1alpha1.ProfileAttributes
-	SectionNameTemplate string
-	NoCredentialProcess bool
+	Config            *ini.File
+	ProfileName       string
+	ProfileAttributes []*awsv1alpha1.ProfileAttributes
 }
 
-func AddProfileToConfig(opts MergeOpts) error {
-	if opts.SectionNameTemplate == "" {
-		opts.SectionNameTemplate = "{{ .AccountName }}/{{ .RoleName }}"
-	}
-
+func Merge(opts MergeOpts) error {
 	profileName := normalizeAccountName(opts.ProfileName)
 
 	sectionName := "profile " + profileName
@@ -32,7 +25,8 @@ func AddProfileToConfig(opts MergeOpts) error {
 	if err != nil {
 		return err
 	}
-	//add all the attributes returned from CF
+
+	// add all the attributes returned from CF
 	for _, item := range opts.ProfileAttributes {
 		_, err := newSection.NewKey(item.Key, item.Value)
 		if err != nil {

--- a/cmd/cli/command/access/ensure.go
+++ b/cmd/cli/command/access/ensure.go
@@ -104,16 +104,6 @@ var ensureCommand = cli.Command{
 			}
 			req.Entitlements = append(req.Entitlements, ent)
 
-			//example profile
-			// [profile demo-sandbox1]
-			// granted_sso_start_url  = https://d-976708da7d.awsapps.com/start
-			// granted_sso_region     = ap-southeast-2
-			// granted_sso_account_id = 616777145260
-			// granted_sso_role_name  = AWSAdministratorAccess
-			// # common_fate_url        = https://internal.commonfate.io
-			// region                 = ap-southeast-2
-			// credential_process     = granted credential-process --profile demo-sandbox1 --url https://internal.prod.granted.run
-
 			gConf, err := grantedConfig.Load()
 			if err != nil {
 				return err

--- a/cmd/cli/command/access/ensure.go
+++ b/cmd/cli/command/access/ensure.go
@@ -116,11 +116,14 @@ var ensureCommand = cli.Command{
 				}
 
 				//build up a new section for each profile being added
-				AddProfileToConfig(MergeOpts{
+				err = AddProfileToConfig(MergeOpts{
 					Config:            awsConfig,
 					ProfileName:       profileFromCF.Msg.Profile.Name,
 					ProfileAttributes: profileFromCF.Msg.Profile.Attributes,
 				})
+				if err != nil {
+					return err
+				}
 			}
 
 		}

--- a/cmd/cli/command/access/ensure.go
+++ b/cmd/cli/command/access/ensure.go
@@ -107,8 +107,8 @@ var ensureCommand = cli.Command{
 			if !disableConfig {
 				profileFromCF, err := accountClient.GetProfileForAccountAndRole(ctx, &connect.Request[awsv1alpha1.GetProfileForAccountAndRoleRequest]{
 					Msg: &awsv1alpha1.GetProfileForAccountAndRoleRequest{
-						AccountId: target,
-						RoleName:  roles[i],
+						AccountName: target,
+						RoleName:    roles[i],
 					},
 				})
 				if err != nil {

--- a/cmd/cli/command/access/profile.go
+++ b/cmd/cli/command/access/profile.go
@@ -34,7 +34,10 @@ func AddProfileToConfig(opts MergeOpts) error {
 	}
 	//add all the attributes returned from CF
 	for _, item := range opts.ProfileAttributes {
-		newSection.NewKey(item.Key, item.Value)
+		_, err := newSection.NewKey(item.Key, item.Value)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/cli/command/access/profile.go
+++ b/cmd/cli/command/access/profile.go
@@ -1,0 +1,45 @@
+package access
+
+import (
+	"strings"
+
+	awsv1alpha1 "github.com/common-fate/sdk/gen/granted/registry/aws/v1alpha1"
+
+	"gopkg.in/ini.v1"
+)
+
+type MergeOpts struct {
+	Config              *ini.File
+	Prefix              string
+	ProfileName         string
+	ProfileAttributes   []*awsv1alpha1.ProfileAttributes
+	SectionNameTemplate string
+	NoCredentialProcess bool
+}
+
+func AddProfileToConfig(opts MergeOpts) error {
+	if opts.SectionNameTemplate == "" {
+		opts.SectionNameTemplate = "{{ .AccountName }}/{{ .RoleName }}"
+	}
+
+	profileName := normalizeAccountName(opts.ProfileName)
+
+	sectionName := "profile " + profileName
+
+	opts.Config.DeleteSection(sectionName)
+
+	newSection, err := opts.Config.NewSection(sectionName)
+	if err != nil {
+		return err
+	}
+	//add all the attributes returned from CF
+	for _, item := range opts.ProfileAttributes {
+		newSection.NewKey(item.Key, item.Value)
+	}
+
+	return nil
+}
+
+func normalizeAccountName(accountName string) string {
+	return strings.ReplaceAll(accountName, " ", "-")
+}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/common-fate/glide-cli v0.6.0
 	github.com/common-fate/grab v1.3.0
 	github.com/common-fate/granted v0.23.0
-	github.com/common-fate/sdk v1.24.1-0.20240417000603-974db8bf32e1
+	github.com/common-fate/sdk v1.26.1
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/common-fate/cli
 
-go 1.21.3
+go 1.22.0
 
 require (
 	connectrpc.com/connect v1.14.0
@@ -14,8 +14,8 @@ require (
 	github.com/common-fate/clio v1.2.3
 	github.com/common-fate/glide-cli v0.6.0
 	github.com/common-fate/grab v1.3.0
-	github.com/common-fate/granted v0.20.6
-	github.com/common-fate/sdk v1.24.1-0.20240416070331-a8b8f3db1ab4
+	github.com/common-fate/granted v0.23.0
+	github.com/common-fate/sdk v1.24.1-0.20240417000603-974db8bf32e1
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/common-fate/glide-cli v0.6.0
 	github.com/common-fate/grab v1.3.0
 	github.com/common-fate/granted v0.20.6
-	github.com/common-fate/sdk v1.22.0
+	github.com/common-fate/sdk v1.24.1-0.20240416070331-a8b8f3db1ab4
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,12 @@ github.com/common-fate/sdk v1.21.1-0.20240408234758-221797ccdc2c h1:1oFNraCWZAdd
 github.com/common-fate/sdk v1.21.1-0.20240408234758-221797ccdc2c/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/sdk v1.22.0 h1:JN/g/x2QjPMKYG70UhMCfo3DyzbZFLHPEswWZSPFqZQ=
 github.com/common-fate/sdk v1.22.0/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
+github.com/common-fate/sdk v1.24.1-0.20240416062624-6594a5a07844 h1:W4YfAli43SqB1KgsX35Ql1DwcntsKs2sGcsRT0p/kGc=
+github.com/common-fate/sdk v1.24.1-0.20240416062624-6594a5a07844/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
+github.com/common-fate/sdk v1.24.1-0.20240416063248-f96a1f528467 h1:4ZzksuSFwtFmVdt5mAfGY/GQI7bT07Gj7JvY2vaPNsk=
+github.com/common-fate/sdk v1.24.1-0.20240416063248-f96a1f528467/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
+github.com/common-fate/sdk v1.24.1-0.20240416070331-a8b8f3db1ab4 h1:kTMqCw+Agq1tznSaiDmvCAYYNglBO7D13QrflFQC41Q=
+github.com/common-fate/sdk v1.24.1-0.20240416070331-a8b8f3db1ab4/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=
 github.com/common-fate/useragent v0.1.0/go.mod h1:GjXGR6cDiMboDP04qlfDfA5HTbeoRSoNgQWDAyOdW9o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/common-fate/grab v1.3.0 h1:vGNBMfhAVAWtrLuH1stnhL4LsDb73drhegC/060q+O
 github.com/common-fate/grab v1.3.0/go.mod h1:6zH8GckZGFrOKfZzL4Y/2OTvxwFeL6cDtsztM0GGC2Y=
 github.com/common-fate/granted v0.20.6 h1:xdtowltCQU/pN9sROXFUYBp4xvOlCqT1j1t2mLkxt7k=
 github.com/common-fate/granted v0.20.6/go.mod h1:KnTghmwZa5cwg/CCJVzdWMcQNqp1APAQfcA1707vQFs=
+github.com/common-fate/granted v0.23.0 h1:J45tl7l7JcBUlGna1J+7DfjA/Wf1Aw5t4l0Ohrd7g6o=
+github.com/common-fate/granted v0.23.0/go.mod h1:gwDLdgp23WD07swm6nryh3b0GNaeCPq1cu+feFlyy1E=
 github.com/common-fate/iso8601 v1.1.0 h1:nrej9shsK1aB4IyOAjZl68xGk8yDuUxVwQjoDzxSK2c=
 github.com/common-fate/iso8601 v1.1.0/go.mod h1:DU4mvUEkkWZUUSJq2aCuNqM1luSb0Pwyb2dLzXS+img=
 github.com/common-fate/provider-registry-sdk-go v0.19.0 h1:V5ZUP5jvNFM0FVXH8akXLb5VxBu22OkKqQTu2CA1goI=
@@ -202,6 +204,10 @@ github.com/common-fate/sdk v1.24.1-0.20240416063248-f96a1f528467 h1:4ZzksuSFwtFm
 github.com/common-fate/sdk v1.24.1-0.20240416063248-f96a1f528467/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/sdk v1.24.1-0.20240416070331-a8b8f3db1ab4 h1:kTMqCw+Agq1tznSaiDmvCAYYNglBO7D13QrflFQC41Q=
 github.com/common-fate/sdk v1.24.1-0.20240416070331-a8b8f3db1ab4/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
+github.com/common-fate/sdk v1.24.1-0.20240416085943-11304a6e48c4 h1:8WPiJ1OSYn//I5bXK2NssayByO3J0AYD3CBOBx9WnZc=
+github.com/common-fate/sdk v1.24.1-0.20240416085943-11304a6e48c4/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
+github.com/common-fate/sdk v1.24.1-0.20240417000603-974db8bf32e1 h1:OkpiaYl0f+Hu5CCAjRYeEAGxpla25dv1zEWgp2xvL/Y=
+github.com/common-fate/sdk v1.24.1-0.20240417000603-974db8bf32e1/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=
 github.com/common-fate/useragent v0.1.0/go.mod h1:GjXGR6cDiMboDP04qlfDfA5HTbeoRSoNgQWDAyOdW9o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/common-fate/sdk v1.24.1-0.20240416085943-11304a6e48c4 h1:8WPiJ1OSYn//
 github.com/common-fate/sdk v1.24.1-0.20240416085943-11304a6e48c4/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/sdk v1.24.1-0.20240417000603-974db8bf32e1 h1:OkpiaYl0f+Hu5CCAjRYeEAGxpla25dv1zEWgp2xvL/Y=
 github.com/common-fate/sdk v1.24.1-0.20240417000603-974db8bf32e1/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
+github.com/common-fate/sdk v1.26.1 h1:exY0o9dRYEp4TxE1y7tpiw3AWl/in3OmNfZtj6gjbJU=
+github.com/common-fate/sdk v1.26.1/go.mod h1:llkDIaaLh3a9tDujSJh8VK690NJsjbpWMwhDhnLNH+M=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=
 github.com/common-fate/useragent v0.1.0/go.mod h1:GjXGR6cDiMboDP04qlfDfA5HTbeoRSoNgQWDAyOdW9o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/profilesource/profilesource.go
+++ b/profilesource/profilesource.go
@@ -1,0 +1,54 @@
+package profilesource
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"github.com/common-fate/awsconfigfile"
+	accessv1alpha1 "github.com/common-fate/sdk/gen/commonfate/access/v1alpha1"
+	accountv1alpha1 "github.com/common-fate/sdk/gen/commonfate/control/account"
+	"github.com/common-fate/sdk/gen/commonfate/control/account/accountv1alpha1connect"
+)
+
+// Source reads available AWS SSO profiles from the Common Fate API.
+// It implements the awsconfigfile.Source interface
+type Source struct {
+	SSORegion    string
+	StartURL     string
+	Client       accountv1alpha1connect.AccountServiceClient
+	DashboardURL string
+	Entitlements []*accessv1alpha1.EntitlementInput
+}
+
+func (s Source) GetProfiles(ctx context.Context) ([]awsconfigfile.SSOProfile, error) {
+	profiles := []awsconfigfile.SSOProfile{}
+	// add all options to our profile map
+	for _, ent := range s.Entitlements {
+
+		//lookup target
+
+		acc, err := s.Client.GetAWSAccountDetail(ctx, &connect.Request[accountv1alpha1.GetAWSAccountDetailRequest]{
+			Msg: &accountv1alpha1.GetAWSAccountDetailRequest{
+				AccountId: ent.Target.GetEid().GetId(),
+			},
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		p := awsconfigfile.SSOProfile{
+			AccountID:     acc.Msg.AccountId,
+			AccountName:   acc.Msg.AccountName,
+			RoleName:      ent.Role.String(),
+			SSOStartURL:   s.StartURL,
+			SSORegion:     s.SSORegion,
+			GeneratedFrom: "commonfate",
+			CommonFateURL: s.DashboardURL,
+		}
+		profiles = append(profiles, p)
+
+	}
+
+	return profiles, nil
+}


### PR DESCRIPTION
Batch ensure will now attempt to create a new profile if it doesn't already exist in `~/.aws/config` for the requested target and role. 

The profile added will be able to request access in Granted as per the updates in https://github.com/common-fate/granted/pull/630

`batch ensure` has been given a flag `disable-config` to disable this functionality in the case that it is blocking the flow for requesting access. Since it makes extra calls to external services outside of the granting flow

Also a design choice was to save these new profiles outside of the granted registry bounds to not interfere with the logic in Granted.
