### PR TITLE
update merge to skip handling inputs because upstream will handle it

### DIFF
--- a/.changeset/big-clocks-kiss.md
+++ b/.changeset/big-clocks-kiss.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": patch
+---
+
+Fix logic for creating profiles based on an entitlement requested with batch ensure

--- a/awsconfig/merge.go
+++ b/awsconfig/merge.go
@@ -1,8 +1,6 @@
 package awsconfig
 
 import (
-	"strings"
-
 	awsv1alpha1 "github.com/common-fate/sdk/gen/granted/registry/aws/v1alpha1"
 
 	"gopkg.in/ini.v1"
@@ -15,13 +13,10 @@ type MergeOpts struct {
 }
 
 func Merge(opts MergeOpts) error {
-	profileName := normalizeAccountName(opts.ProfileName)
 
-	sectionName := "profile " + profileName
+	opts.Config.DeleteSection(opts.ProfileName)
 
-	opts.Config.DeleteSection(sectionName)
-
-	newSection, err := opts.Config.NewSection(sectionName)
+	newSection, err := opts.Config.NewSection(opts.ProfileName)
 	if err != nil {
 		return err
 	}
@@ -35,8 +30,4 @@ func Merge(opts MergeOpts) error {
 	}
 
 	return nil
-}
-
-func normalizeAccountName(accountName string) string {
-	return strings.ReplaceAll(accountName, " ", "-")
 }


### PR DESCRIPTION
Updated the upstream logic for handling profiles, which handles the profile name before sending it to the cli. Meaning we did not need the logic here for normalizing and setting profile names.