### PR TITLE
Fixes an issue where the CLI was displaying an incorrect time for the duration to be extended by

### DIFF
--- a/.changeset/selfish-pumas-pull.md
+++ b/.changeset/selfish-pumas-pull.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": patch
+---
+
+Fixes an issue where the CLI was displaying an incorrect time for the duration to be extended by.

--- a/cmd/cli/command/access/dry_run.go
+++ b/cmd/cli/command/access/dry_run.go
@@ -73,8 +73,12 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 			continue
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_EXTENDED:
+			extendedTime := ""
+			if g.Grant.Extension != nil {
+				extendedTime = ShortDur(g.Grant.Extension.ExtensionDurationSeconds.AsDuration())
+			}
 			color.New(color.BgBlue).Printf("[WILL EXTEND]")
-			color.New(color.FgBlue).Printf(" %s will be extended for another %s: %s\n", g.Grant.Name, exp, RequestURL(apiURL, g.Grant))
+			color.New(color.FgBlue).Printf(" %s will be extended for another %s: %s\n", g.Grant.Name, extendedTime, RequestURL(apiURL, g.Grant))
 			continue
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:

--- a/cmd/cli/command/access/ensure.go
+++ b/cmd/cli/command/access/ensure.go
@@ -183,8 +183,13 @@ var ensureCommand = cli.Command{
 					continue
 
 				case accessv1alpha1.GrantChange_GRANT_CHANGE_EXTENDED:
+					extendedTime := ""
+					if g.Grant.Extension != nil {
+						extendedTime = ShortDur(g.Grant.Extension.ExtensionDurationSeconds.AsDuration())
+					}
 					color.New(color.BgBlue).Printf("[EXTENDED]")
-					color.New(color.FgBlue).Printf(" %s was extended for another %s: %s\n", g.Grant.Name, exp, RequestURL(apiURL, g.Grant))
+					color.New(color.FgBlue).Printf(" %s was extended for another %s: %s\n", g.Grant.Name, extendedTime, RequestURL(apiURL, g.Grant))
+					color.New(color.FgGreen).Printf(" %s will now expire in %s\n", g.Grant.Name, exp)
 					continue
 
 				case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:


### PR DESCRIPTION
Before:

Incorrectly shows the time that it is extending by

```
❯ cf access ensure --target CommonFateDemo --role AWSReadOnlyAccess --reason test
[WILL ACTIVATE] AWSReadOnlyAccess access to CommonFateDemo will be activated for 1h: https://internal.commonfate.io/access/requests/req_2jycZ1025Oj98wT3qj7lROtuiHh
[i] Access::Grant::"gra_2jycZ1i8ZmY5kSupLjLcUS0oq1P": read only AWS access is automatically approved
? Apply proposed access changes Yes
⠦ ensuring access...[i] Access::Grant::"gra_2jycZZpnFULL7O9uUbMBsVtkmrj": read only AWS access is automatically approved
[i] adding profile CommonFateDemo/AWSReadOnlyAccess to your AWS config file (/Users/testing/.aws/config)	[target=CommonFateDemo, role=AWSReadOnlyAccess]
[ACTIVATED] AWSReadOnlyAccess access to CommonFateDemo was activated for 1h: https://internal.commonfate.io/access/requests/req_2jycZdXSHoGOWakm0q9fotx15TG
[i] Access::Grant::"gra_2jycZZpnFULL7O9uUbMBsVtkmrj": read only AWS access is automatically approved

~ on  main [?] on ☁️  shwetha@commonfate.io took 18s 
❯ cf access ensure --target CommonFateDemo --role AWSReadOnlyAccess --reason test
[WILL EXTEND] AWSReadOnlyAccess access to CommonFateDemo will be extended for another 2h: https://internal.commonfate.io/access/requests/req_2jycZdXSHoGOWakm0q9fotx15TG
? Apply proposed access changes Yes
[i] adding profile CommonFateDemo/AWSReadOnlyAccess to your AWS config file (/Users/testing/.aws/config)	[target=CommonFateDemo, role=AWSReadOnlyAccess]
[EXTENDED] AWSReadOnlyAccess access to CommonFateDemo was extended for another 2h: https://internal.commonfate.io/access/requests/req_2jycZdXSHoGOWakm0q9fotx15TG

~ on  main [?] on ☁️  shwetha@commonfate.io took 19s 
❯ cf access ensure --target CommonFateDemo --role AWSReadOnlyAccess --reason test
[WILL EXTEND] AWSReadOnlyAccess access to CommonFateDemo will be extended for another 2h59m: https://internal.commonfate.io/access/requests/req_2jycZdXSHoGOWakm0q9fotx15TG
? Apply proposed access changes Yes
[i] adding profile CommonFateDemo/AWSReadOnlyAccess to your AWS config file (/Users/testing/.aws/config)	[target=CommonFateDemo, role=AWSReadOnlyAccess]
[EXTENDED] AWSReadOnlyAccess access to CommonFateDemo was extended for another 2h59m: https://internal.commonfate.io/access/requests/req_2jycZdXSHoGOWakm0q9fotx15TG
```

After:

Properly displays correct time to be extended by, as well as when it will expire
![Screenshot 2024-08-05 at 10 20 33 AM](https://github.com/user-attachments/assets/671f59f2-ef2a-4c92-833a-d0d76c974667)

Sanity check that the CF Web Console is behaving as expected
![Screenshot 2024-08-05 at 10 24 19 AM](https://github.com/user-attachments/assets/df6a8bef-022d-47df-a8b2-b11b6df2151e)

![Screenshot 2024-08-05 at 10 24 28 AM](https://github.com/user-attachments/assets/8ab7c0fa-a3de-47be-a1ae-60f00b9a9f17)
