### PR TITLE
Implementing Multiple ExpectedResult for Access Tests

### DIFF
--- a/.changeset/ninety-donuts-destroy.md
+++ b/.changeset/ninety-donuts-destroy.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": patch
+---
+
+Adds support for providing multiple values to the ExpectedResult configuration option for access tests, permitting testing complex access scenarios.


### PR DESCRIPTION
# Description 

## Problem:

Currently, for access testing, if `ExpectedResult` is set to `requires-approval` and the user is instead _auto-approved_, the test fails. However, there are scenarios, such as during on-call rotations, where a user's access might be _auto-approved_ when on-call but _requires-approval_ when not on-call.

## Solution:

This PR introduces the ability to specify `ExpectedResult` as a list of strings. This allows you to define multiple acceptable outcomes, such as both _requires-approval_ and _auto-approved_, ensuring the test passes if either state is valid.

## Backwards Compatibility:

The change is fully backwards compatible with existing configurations, supporting both a single string and a list of strings for `ExpectedResult`.

## Example:

### Configuration:

```yaml
access-tests:
  - user: chris@commonfate.io
    target: management
    role: AdministratorAccess
    expected-result: 
      - requires-approval
      - auto-approved
```

### Test Result:

Result is **auto-approved**:

```
[PASS] chris@commonfate.io auto-approved to management with role AdministratorAccess
```

Result is **requires-approval**:

```
[PASS] chris@commonfate.io requires-approval to management with role AdministratorAccess
```