### PR TITLE
update file perm used when creating cf config

### DIFF
--- a/.changeset/sixty-lamps-love.md
+++ b/.changeset/sixty-lamps-love.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/cli": patch
+---
+
+fix permissions when creating cf config files to exclude execute permission

--- a/awsconfig/config.go
+++ b/awsconfig/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// permission for user to read/write/execute.
+	// permission for user to read/write.
 	USER_READ_WRITE_PERM = 0644
 )
 

--- a/awsconfig/config.go
+++ b/awsconfig/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// permission for user to read/write/execute.
-	USER_READ_WRITE_PERM = 0700
+	USER_READ_WRITE_PERM = 0644
 )
 
 func loadAWSConfigFileFromPath(filepath string) (*ini.File, error) {


### PR DESCRIPTION
Updates file permissions used when creating the cf config file to allow for read/write and not execute