### PR TITLE
Revert "update file perm used when creating cf config"

### DIFF
--- a/.changeset/sixty-lamps-love.md
+++ b/.changeset/sixty-lamps-love.md
@@ -1,5 +1,0 @@
----
-"@common-fate/cli": patch
----
-
-fix permissions when creating cf config files to exclude execute permission

--- a/awsconfig/config.go
+++ b/awsconfig/config.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
+	// permission for user to read/write/execute.
+	USER_READ_WRITE_PERM = 0700
 )
 
 func loadAWSConfigFileFromPath(filepath string) (*ini.File, error) {


### PR DESCRIPTION
Reverts common-fate/cli#95 - the directory here should be `0700`. Fixes the same issue fixed in https://github.com/common-fate/granted/pull/755